### PR TITLE
add setters and getters for baseUri on main Starweb and TokenManager class

### DIFF
--- a/src/Api/Authentication/TokenManager.php
+++ b/src/Api/Authentication/TokenManager.php
@@ -59,6 +59,21 @@ class TokenManager
         $this->baseUri = $baseUri;
     }
 
+    /**
+     * @param string $baseUri
+     */
+    public function setBaseUri(string $baseUri): void
+    {
+        $this->baseUri = $baseUri;
+    }
+
+    /**
+     * @return string
+     */
+    public function getBaseUri(): string
+    {
+        return $this->baseUri;
+    }
 
     /**
      * @param HttpClient $client

--- a/src/Starweb.php
+++ b/src/Starweb.php
@@ -165,4 +165,15 @@ class Starweb
 
         return $resource;
     }
+
+    public function setBaseUri(string $baseUri): void
+    {
+        $this->baseUri = $baseUri;
+        $this->tokenManager->setBaseUri($baseUri);
+    }
+
+    public function getBaseUri(): string
+    {
+        return $this->baseUri;
+    }
 }

--- a/tests/unit/Api/Authentication/TokenManagerTest.php
+++ b/tests/unit/Api/Authentication/TokenManagerTest.php
@@ -18,6 +18,7 @@ use Starweb\Api\Authentication\TokenManager;
 
 class TokenManagerTest extends TestCase
 {
+    private const DEFAULT_BASE_URI = 'https://demo.starweb.se/api/v2';
 
     public function testConstructor()
     {
@@ -85,6 +86,15 @@ class TokenManagerTest extends TestCase
         $this->assertNull($manager->refreshToken());
     }
 
+    public function testSetAndGetBaseUri()
+    {
+        $tokenManager = $this->getTokenManager();
+        $this->assertEquals(self::DEFAULT_BASE_URI, $tokenManager->getBaseUri());
+
+        $tokenManager->setBaseUri('https://example.com/api');
+        $this->assertEquals('https://example.com/api', $tokenManager->getBaseUri());
+    }
+
     private function getTokenManager(ResponseInterface $response = null, TokenCacheInterface $cache = null)
     {
         $client = new Client();
@@ -110,7 +120,7 @@ class TokenManagerTest extends TestCase
             $messageFactory,
             new ClientCredentials('id', 'secret'),
             $cache,
-            'http://demo.startweb.se/api/v2'
+            self::DEFAULT_BASE_URI
         );
     }
 }

--- a/tests/unit/StarwebTest.php
+++ b/tests/unit/StarwebTest.php
@@ -22,6 +22,8 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class StarwebTest extends TestCase
 {
+    private const DEFAULT_BASE_URI = 'https://demo.starweb.se/api/v2';
+
     /**
      * @var StreamFactory
      */
@@ -39,7 +41,7 @@ class StarwebTest extends TestCase
      */
     public function testConstructorWithoutClientAndTokenCache()
     {
-        $starweb = new Starweb(new ClientCredentials('id', 'secret'), 'https://demo.starweb.se/api/v2');
+        $starweb = new Starweb(new ClientCredentials('id', 'secret'), self::DEFAULT_BASE_URI);
 
         $this->assertInstanceOf(Starweb::class, $starweb);
     }
@@ -65,7 +67,7 @@ class StarwebTest extends TestCase
 
         $starweb = new Starweb(
             new ClientCredentials('id', 'secret'),
-            'https://demo.starweb.se/api/v2',
+            self::DEFAULT_BASE_URI,
             $client
         );
     }
@@ -89,7 +91,7 @@ class StarwebTest extends TestCase
 
         return new Starweb(
             new ClientCredentials('id', 'secret'),
-            'https://demo.starweb.se/api/v2',
+            self::DEFAULT_BASE_URI,
             $client,
             $messageFactory,
             $cache
@@ -116,7 +118,6 @@ class StarwebTest extends TestCase
         }
 
         $resource = $starweb->resource($resourceKey, $parameters);
-
 
         $this->assertInstanceOf(ResourceInterface::class, $resource);
         $this->assertInstanceOf(Resource::class, $resource);
@@ -149,5 +150,14 @@ class StarwebTest extends TestCase
         }
 
         return $this->streamFactory;
+    }
+
+    public function testSetAndGetBaseUri()
+    {
+        $starweb = $this->getStarweb();
+        $this->assertEquals($starweb->getBaseUri(), self::DEFAULT_BASE_URI);
+
+        $starweb->setBaseUri('https://example.com/api');
+        $this->assertEquals('https://example.com/api', $starweb->getBaseUri());
     }
 }


### PR DESCRIPTION
To use the sdk in a dynamic context like the Import Microservice (IMS) we need to update the `baseUri` which gets injected in the constructor at a later stage. This PR adds setters and getters to the main SDK (`Starweb`) and the related `TokenManager` class.