### PR TITLE
decouple the http client building from the constructor

### DIFF
--- a/tests/unit/StarwebTest.php
+++ b/tests/unit/StarwebTest.php
@@ -36,9 +36,6 @@ class StarwebTest extends TestCase
         $this->assertInstanceOf(Starweb::class, $starweb);
     }
 
-    /**
-     * @expectedException \Starweb\Exception\InvalidCredentialsException
-     */
     public function testConstructorWithoutClientAndTokenCache()
     {
         $starweb = new Starweb(new ClientCredentials('id', 'secret'), self::DEFAULT_BASE_URI);
@@ -48,8 +45,6 @@ class StarwebTest extends TestCase
 
     /**
      * this is a real life test on the demo api with wrong credentials
-     *
-     * @expectedException \Starweb\Exception\InvalidCredentialsException
      */
     public function testConstructorWithInvalidCredentials()
     {
@@ -70,6 +65,8 @@ class StarwebTest extends TestCase
             self::DEFAULT_BASE_URI,
             $client
         );
+
+        $this->assertInstanceOf(Starweb::class, $starweb);
     }
 
     private function getStarweb(): Starweb
@@ -141,6 +138,15 @@ class StarwebTest extends TestCase
     {
         $starweb = $this->getStarweb();
         $resource = $starweb->resource('InvalidResource');
+    }
+
+    /**
+     * @expectedException \LogicException
+     */
+    public function testResourceWithoutBaseUriSet()
+    {
+        $starweb = new Starweb(new ClientCredentials('id', 'secret'));
+        $resource = $starweb->resource(Resources::CUSTOMER);
     }
 
     private function getStreamFactory()


### PR DESCRIPTION
The creation of the `TokenManager` and building the `httpClient` have been coupled inside the constructor of the main `Starweb` class.  The baseUri is needed from the `TokenManager` which itself is used in the clients build process when adding authentication (fetching access token using the client credentials). 

This PR removes the coupling and makes the `baseUri` in the constructor optional, allowing a more flexible approach to create the main sdk object and setting the `baseUri` later.