### PR TITLE
Fix: ProductStockStatus::languages 

### DIFF
--- a/src/Api/Model/ProductStockStatus/ProductStockStatus.php
+++ b/src/Api/Model/ProductStockStatus/ProductStockStatus.php
@@ -18,9 +18,7 @@ class ProductStockStatus
      */
     protected $inStock;
     /**
-     *
-     *
-     * @var ProductStockStatusLanguage[]
+     * @var ProductStockStatusLanguageCollection
      */
     protected $languages;
     /**
@@ -45,7 +43,7 @@ class ProductStockStatus
      * This has to be set to another, existing stock status id, or null. If a product has its quantity changed to
      * negative, the product will then change stock status to the one with this id
      *
-     * @var int
+     * @var ?int
      */
     protected $stockoutNewStatusId;
 
@@ -100,23 +98,19 @@ class ProductStockStatus
     }
 
     /**
-     *
-     *
-     * @return ProductStockStatusLanguage[]
+     * @return ProductStockStatusLanguageCollection
      */
-    public function getLanguages(): array
+    public function getLanguages(): ProductStockStatusLanguageCollection
     {
         return $this->languages;
     }
 
     /**
-     *
-     *
-     * @param ProductStockStatusLanguage[]
+     * @param ProductStockStatusLanguageCollection
      *
      * @return self
      */
-    public function setLanguages(array $languages): self
+    public function setLanguages(ProductStockStatusLanguageCollection $languages): self
     {
         $this->languages = $languages;
 
@@ -210,11 +204,11 @@ class ProductStockStatus
      * This has to be set to another, existing stock status id, or null. If a product has its quantity changed to
      * negative, the product will then change stock status to the one with this id
      *
-     * @param int $stockoutNewStatusId
+     * @param int|null $stockoutNewStatusId
      *
      * @return self
      */
-    public function setStockoutNewStatusId(int $stockoutNewStatusId): self
+    public function setStockoutNewStatusId(?int $stockoutNewStatusId): self
     {
         $this->stockoutNewStatusId = $stockoutNewStatusId;
 

--- a/src/Api/Model/ProductStockStatus/ProductStockStatusLanguageCollection.php
+++ b/src/Api/Model/ProductStockStatus/ProductStockStatusLanguageCollection.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Starweb\Api\Model\ProductStockStatus;
+
+class ProductStockStatusLanguageCollection
+{
+    /**
+     * A list of product stock statuses
+     *
+     * @var ProductStockStatusLanguage[]
+     */
+    protected $data;
+
+    /**
+     * A list of product stock statuses
+     *
+     * @return ProductStockStatus[]
+     */
+    public function getData(): array
+    {
+        return $this->data;
+    }
+
+    /**
+     * A list of product stock statuses
+     *
+     * @param ProductStockStatusLanguage[]
+     *
+     * @return self
+     */
+    public function setData(array $data): self
+    {
+        $this->data = $data;
+
+        return $this;
+    }
+}


### PR DESCRIPTION
https://favro.com/organization/d98323ed4cfac48a92f11bf7/ce2fdb286ec7331714f87def?card=Sta-6439

The languages need to be a collection with a `data` namespace as this is what is actually returned by the SWS Shop API. The current specification about the response object is wrong about that.  