### PR TITLE
fix jane-php requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
         "symfony/property-access": "^4.1",
         "symfony/property-info": "^4.1",
         "symfony/options-resolver": "^4.1",
-        "psr/simple-cache": "^1.0"
+        "psr/simple-cache": "^1.0",
+        "jane-php/jane-php": "dev-master"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.1",
@@ -38,7 +39,6 @@
         "guzzlehttp/psr7": "^1.4",
         "php-http/mock-client": "^1.1",
         "squizlabs/php_codesniffer": "^3.3",
-        "jane-php/jane-php": "dev-master"
     },
     "autoload": {
         "psr-4": {"Starweb\\": "src/"}

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "php-http/guzzle6-adapter": "^1.0",
         "guzzlehttp/psr7": "^1.4",
         "php-http/mock-client": "^1.1",
-        "squizlabs/php_codesniffer": "^3.3",
+        "squizlabs/php_codesniffer": "^3.3"
     },
     "autoload": {
         "psr-4": {"Starweb\\": "src/"}


### PR DESCRIPTION
require jane-php/jane-php package as the runtinme exists only as subtree split so we need to require the whole package in order to run the sdk in non dev mode

fixes #15 