### PR TITLE
Bugfix: identifier collision in AddPathPlugin

### DIFF
--- a/src/HttpClient/Plugin/AddPathPlugin.php
+++ b/src/HttpClient/Plugin/AddPathPlugin.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types=1);
+
+namespace Starweb\HttpClient\Plugin;
+
+use Http\Client\Common\Plugin;
+use Http\Promise\Promise;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\UriInterface;
+
+/**
+ * Customized AddPathPlugin from php-http/client-common:2.x branch.
+ *
+ * @see https://github.com/php-http/client-common/blob/2.0.0/src/Plugin/AddPathPlugin.php
+ * @see https://github.com/php-http/client-common/issues/171
+ * @see https://github.com/php-http/client-common/issues/141
+ */
+final class AddPathPlugin implements Plugin
+{
+    /**
+     * The URI.
+     *
+     * @var \Psr\Http\Message\UriInterface
+     */
+    private $uri;
+
+    /**
+     * AddPathPlugin constructor.
+     *
+     * @param \Psr\Http\Message\UriInterface $uri
+     *   The URI.
+     */
+    public function __construct(UriInterface $uri)
+    {
+        if ('' === $uri->getPath()) {
+            throw new \InvalidArgumentException('URI path cannot be empty');
+        }
+        if ('/' === substr($uri->getPath(), -1)) {
+            $uri = $uri->withPath(rtrim($uri->getPath(), '/'));
+        }
+        $this->uri = $uri;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
+    {
+        $prepend = $this->uri->getPath();
+        $path = $request->getUri()->getPath();
+        if (0 !== strpos($path, $prepend)) {
+            $request = $request->withUri($request->getUri()->withPath($prepend . $path));
+        }
+
+        return $next($request);
+    }
+}

--- a/src/HttpClient/Plugin/BaseUriPlugin.php
+++ b/src/HttpClient/Plugin/BaseUriPlugin.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types=1);
+
+namespace Starweb\HttpClient\Plugin;
+
+use Http\Client\Common\Plugin;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\UriInterface;
+use Http\Client\Common\Plugin\AddHostPlugin;
+
+/**
+ * Forked version of the original plugin from the php-http/client-common:1.x branch which uses our custom fixed
+ * version of the AddPathPlugin regarding identifiert collision
+ *
+ * @see AddPathPlugin
+ * @see https://github.com/php-http/client-common/blob/1.9.1/src/Plugin/BaseUriPlugin.php
+ *
+ * Combines the AddHostPlugin and AddPathPlugin.
+ *
+ * @author Sullivan Senechal <soullivaneuh@gmail.com>
+ */
+final class BaseUriPlugin implements Plugin
+{
+    /**
+     * @var AddHostPlugin
+     */
+    private $addHostPlugin;
+
+    /**
+     * @var AddPathPlugin|null
+     */
+    private $addPathPlugin = null;
+
+    /**
+     * @param UriInterface $uri        Has to contain a host name and cans have a path.
+     * @param array        $hostConfig Config for AddHostPlugin. @see AddHostPlugin::configureOptions
+     */
+    public function __construct(UriInterface $uri, array $hostConfig = [])
+    {
+        $this->addHostPlugin = new AddHostPlugin($uri, $hostConfig);
+
+        if (rtrim($uri->getPath(), '/')) {
+            $this->addPathPlugin = new AddPathPlugin($uri);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handleRequest(RequestInterface $request, callable $next, callable $first)
+    {
+        $addHostNext = function (RequestInterface $request) use ($next, $first) {
+            return $this->addHostPlugin->handleRequest($request, $next, $first);
+        };
+
+        if ($this->addPathPlugin) {
+            return $this->addPathPlugin->handleRequest($request, $addHostNext, $first);
+        }
+
+        return $addHostNext($request);
+    }
+}

--- a/src/Starweb.php
+++ b/src/Starweb.php
@@ -2,7 +2,6 @@
 
 namespace Starweb;
 
-use Http\Client\Common\Plugin\BaseUriPlugin;
 use Http\Client\Common\Plugin\HeaderDefaultsPlugin;
 use Http\Client\HttpClient;
 use Http\Discovery\MessageFactoryDiscovery;
@@ -15,6 +14,7 @@ use Starweb\HttpClient\Builder;
 use Http\Discovery\HttpClientDiscovery;
 use Starweb\Api\Authentication\ClientCredentials;
 use Starweb\Api\Authentication\TokenCacheInterface;
+use Starweb\HttpClient\Plugin\BaseUriPlugin;
 use Starweb\HttpClient\Plugin\ErrorPlugin;
 use Starweb\HttpClient\Plugin\RetryAuthenticationPlugin;
 


### PR DESCRIPTION
fixes the identifier collision by replacing the AddPathPlugin with the one from the 2.x branch

