### PR TITLE
add .coveralls.yml configuration defining the default json path

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+json_path: coveralls-upload.json


### PR DESCRIPTION
adds coveralls configuration to set the json path to the project root, the same location the clover code coverage report is generated to
