### PR TITLE
adds support to recognize request limit error to the error plugin 

### DIFF
--- a/src/HttpClient/Plugin/ErrorPlugin.php
+++ b/src/HttpClient/Plugin/ErrorPlugin.php
@@ -42,7 +42,7 @@ use Psr\Http\Message\ResponseInterface;
  */
 final class ErrorPlugin implements Plugin
 {
-    private const SECONDS_TO_SLEEP_ON_MAX_REQUEST_PER_LIMIT_ERROR = 5;
+    private const SECONDS_TO_SLEEP_ON_MAX_REQUEST_PER_MINUTE_ERROR = 5;
 
     /**
      * {@inheritdoc}
@@ -79,7 +79,7 @@ final class ErrorPlugin implements Plugin
 
                 // Starweb Shop API SDKs limit is 1000 requests per minute, so we sleep in incremental
                 // steps of seconds before we restart the request processing chain
-                sleep(self::SECONDS_TO_SLEEP_ON_MAX_REQUEST_PER_LIMIT_ERROR);
+                sleep(self::SECONDS_TO_SLEEP_ON_MAX_REQUEST_PER_MINUTE_ERROR);
                 $first($request);
             } else {
                 throw new ClientErrorException($content['error_description'], $request, $response);

--- a/src/HttpClient/Plugin/ErrorPlugin.php
+++ b/src/HttpClient/Plugin/ErrorPlugin.php
@@ -42,6 +42,8 @@ use Psr\Http\Message\ResponseInterface;
  */
 final class ErrorPlugin implements Plugin
 {
+    private const SECONDS_TO_SLEEP_ON_MAX_REQUEST_PER_LIMIT_ERROR = 5;
+
     /**
      * {@inheritdoc}
      */
@@ -49,8 +51,8 @@ final class ErrorPlugin implements Plugin
     {
         $promise = $next($request);
 
-        return $promise->then(function (ResponseInterface $response) use ($request) {
-            return $this->transformResponseToException($request, $response);
+        return $promise->then(function (ResponseInterface $response) use ($request, $first) {
+            return $this->transformResponseToException($request, $response, $first);
         });
     }
 
@@ -65,12 +67,23 @@ final class ErrorPlugin implements Plugin
      *
      * @return ResponseInterface If status code is not in 4xx or 5xx return response
      */
-    protected function transformResponseToException(RequestInterface $request, ResponseInterface $response)
-    {
+    protected function transformResponseToException(
+        RequestInterface $request,
+        ResponseInterface $response,
+        callable $first
+    ) {
         if ($response->getStatusCode() >= 400 && $response->getStatusCode() < 500) {
             $content = \json_decode($response->getBody()->__toString(), true);
 
-            throw new ClientErrorException($content['error_description'], $request, $response);
+            if ($this->isMaxRequestsLimitResponse($content)) {
+
+                // Starweb Shop API SDKs limit is 1000 requests per minute, so we sleep in incremental
+                // steps of seconds before we restart the request processing chain
+                sleep(self::SECONDS_TO_SLEEP_ON_MAX_REQUEST_PER_LIMIT_ERROR);
+                $first($request);
+            } else {
+                throw new ClientErrorException($content['error_description'], $request, $response);
+            }
         }
 
         if ($response->getStatusCode() >= 500 && $response->getStatusCode() < 600) {
@@ -78,5 +91,14 @@ final class ErrorPlugin implements Plugin
         }
 
         return $response;
+    }
+
+    private function isMaxRequestsLimitResponse(array $content): bool
+    {
+        if (!array_key_exists('error', $content)) {
+            return false;
+        }
+
+        return $content['error'] === 'Too Many Requests';
     }
 }


### PR DESCRIPTION
https://favro.com/organization/d98323ed4cfac48a92f11bf7/ce2fdb286ec7331714f87def?card=Sta-11929

Adds support to recognize max request errors from the SWS Shop API which will be returned if we send more than 1000 request per minute. Solve this by sleeping in incremental steps of five seconds before resending the request